### PR TITLE
WIP: ✨ display next track if one was selected

### DIFF
--- a/src/components/NextTrack.vue
+++ b/src/components/NextTrack.vue
@@ -1,0 +1,66 @@
+<template>
+  <v-subheader v-if="hasNext" class="v-btn overline">
+    <span class="font-weight-regular">Next:</span>
+    <span class="custom-transform-class text-none font-weight-bold">{{trackData.title}}</span>
+    <span class="custom-transform-class text-none font-weight-thin"> von </span>
+    <span class="custom-transform-class text-none">{{trackData.artist}}</span>
+  </v-subheader>
+</template>
+
+<script>
+import axios from "axios";
+import { mapGetters } from "vuex";
+
+const POLL_TIMEOUT = 3000;
+
+export default {
+  name: "NextTrack",
+  created() {
+    let poll = async () => {
+      try {
+        let response = await axios.get("/data/prio.m3u", {
+          timeout: POLL_TIMEOUT - 100,
+          headers: {
+            "If-Modified-Since": "invalid"
+          }
+        });
+        this.prioPlaylist = response.data.trim();
+      } catch (err) {
+        this.error(
+          `Der nächste Track konnte nicht abgefragt werden: ${err.message}`
+        );
+        this.prioPlaylist = "";
+      }
+    };
+
+    this.polling = setInterval(poll, POLL_TIMEOUT);
+    poll();
+  },
+  beforeDestroy() {
+    clearInterval(this.polling);
+  },
+
+  data() {
+    return {
+      prioPlaylist: ""
+    };
+  },
+  computed: {
+    ...mapGetters(["data"]),
+    hasNext() {
+      return this.prioPlaylist != "";
+    },
+    trackData() {
+      return this.data[
+        this.prioPlaylist
+          .split("/")
+          .pop()
+          .split(".")
+          .shift()
+      ];
+    }
+  }
+};
+</script>
+
+<style></style>

--- a/src/components/Status.vue
+++ b/src/components/Status.vue
@@ -1,5 +1,6 @@
 <template>
   <v-toolbar-items class="disable-events">
+    <NextTrack/>
     <template v-if="online">
       <v-btn small tile depressed :ripple="false" text>{{currentSong}}</v-btn>
       <v-btn small depressed tile :disabled="!onair" :ripple="false" text>
@@ -22,6 +23,7 @@
 <script>
 import axios from "axios";
 import { mapGetters, mapMutations } from "vuex";
+import NextTrack from "@/components/NextTrack.vue";
 
 const POLL_TIMEOUT = 3000;
 
@@ -90,6 +92,9 @@ export default {
   },
   methods: {
     ...mapMutations(["setOnline", "setOffline", "error"])
+  },
+  components: {
+    NextTrack,
   }
 };
 </script>


### PR DESCRIPTION
UI parts of fixing https://github.com/radiorabe/klangbecken/issues/52.

* [x] fix text layout (esp. regarding the italic artist, kerning and uppercasing)
* [ ] do we really want this in the header
* [ ] is polling the right solution? Should we think about websockets?

## screenshot
with active next track:
<img width="738" alt="Screenshot 2020-06-03 at 16 30 48" src="https://user-images.githubusercontent.com/116588/83649597-aab7ec80-a5b7-11ea-82bb-c9cbd52a18cf.png">
without next track in queue:
<img width="775" alt="Screenshot 2020-06-03 at 16 33 01" src="https://user-images.githubusercontent.com/116588/83649842-f074b500-a5b7-11ea-82c6-d225d17f1c6c.png">
