### PR TITLE
fix: use computed prop so we can mutate it w/o dom reload side effects

### DIFF
--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -1,7 +1,7 @@
 <template>
   <v-row justify="center">
     <v-dialog
-      v-model="show"
+      v-model="showForm"
       persistent
       max-width="300"
       :disabled="checking"
@@ -60,7 +60,10 @@ export default {
   },
   props: ["show"],
   computed: {
-    ...mapGetters(["isLoggedIn", "username"])
+    ...mapGetters(["isLoggedIn", "username"]),
+    showForm() {
+      return this.show;
+    }
   },
   methods: {
     async tryLogin() {

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -1,7 +1,7 @@
 <template>
   <v-row justify="center">
     <v-dialog
-      v-model="showForm"
+      :value="show"
       persistent
       max-width="300"
       :disabled="checking"
@@ -61,9 +61,6 @@ export default {
   props: ["show"],
   computed: {
     ...mapGetters(["isLoggedIn", "username"]),
-    showForm() {
-      return this.show;
-    }
   },
   methods: {
     async tryLogin() {

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -60,7 +60,7 @@ export default {
   },
   props: ["show"],
   computed: {
-    ...mapGetters(["isLoggedIn", "username"]),
+    ...mapGetters(["isLoggedIn", "username"])
   },
   methods: {
     async tryLogin() {


### PR DESCRIPTION
This is part of preparing for eslint v7 and it's the "standard" fix for simple getting rid of the following linter error:

```
error: Unexpected mutation of "show" prop (vue/no-mutating-props) at src/components/Login.vue:4:16
```

Instead of merging this we might also consider a more aggressive refactoring on the login component, but then again what we already have is working fine and the user base isn't large enough to warrant making the login experience nicer (ie. by supporting sso through keycloak).