### PR TITLE
feat: prompt page reload on API update

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -56,6 +56,7 @@
     <Login :show="showLogin" @done="showLogin = false" />
     <PreviewPlayer />
     <Notifications />
+    <NeedReload :show="needReload"/>
   </v-app>
 </template>
 
@@ -64,6 +65,7 @@ import axios from "axios";
 import { mapGetters, mapMutations, mapActions } from "vuex";
 
 import Login from "@/components/Login.vue";
+import NeedReload from "@/components/NeedReload.vue";
 import Notifications from "@/components/Notifications.vue";
 import PreviewPlayer from "@/components/PreviewPlayer.vue";
 import Status from "@/components/Status.vue";
@@ -91,7 +93,7 @@ export default {
     };
   },
   computed: {
-    ...mapGetters(["isLoggedIn", "username", "loadingData"])
+    ...mapGetters(["isLoggedIn", "username", "loadingData", "needReload"])
   },
   async created() {
     this.loadData();
@@ -127,6 +129,7 @@ export default {
   },
   components: {
     Login,
+    NeedReload,
     Notifications,
     PreviewPlayer,
     Status

--- a/src/components/NeedReload.vue
+++ b/src/components/NeedReload.vue
@@ -1,0 +1,32 @@
+<template>
+  <v-row justify="center">
+    <v-dialog
+      :value="show"
+      persistent
+      max-width="500"
+    >
+      <v-card>
+        <v-card-title class="headline">Bitte Seite neu laden</v-card-title>
+        <v-card-text>
+          Für die Applikation wurde ein Update eingespielt. Bitte die Seite neu laden, um die Änderungen zu laden.
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn color="secondary" @click="reload">Neu laden</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </v-row>
+</template>
+
+<script>
+export default {
+  name: "NeedReload",
+  props: ["show"],
+  methods: {
+    reload() {
+        window.location.reload()
+    },
+  },
+}
+</script>

--- a/src/store/info.js
+++ b/src/store/info.js
@@ -4,6 +4,7 @@ export default {
     state: {
         state: "offline",
         info: {},
+        apiVersion: '',
         needReload: false,
     },
 
@@ -20,9 +21,13 @@ export default {
         setOffline: (state) => { state.state = "offline" },
         setNotRunning: (state) => {state.state = "not_running" },
         setInfo: (state, newInfo) => {
-            let oldVersion = state.info.api_version;
             state.info = newInfo;
-            if (oldVersion && oldVersion !== newInfo.api_version) {
+
+            let oldVersion = state.apiVersion;
+            let newVersion = newInfo.api_version;
+            if (!oldVersion && newVersion) {
+                state.apiVersion = newVersion
+            } else if (oldVersion && newVersion && oldVersion !== newVersion) {
                 state.needReload = true;
             }
         },

--- a/src/store/info.js
+++ b/src/store/info.js
@@ -4,6 +4,7 @@ export default {
     state: {
         state: "offline",
         info: {},
+        needReload: false,
     },
 
     getters: {
@@ -11,6 +12,7 @@ export default {
         online: (state) => state.state === "online",
         info: (state) => state.info,
         onAir: (state) => state.state === "online" && state.info.on_air,
+        needReload: (state) => state.needReload,
     },
 
     mutations: {
@@ -18,7 +20,11 @@ export default {
         setOffline: (state) => { state.state = "offline" },
         setNotRunning: (state) => {state.state = "not_running" },
         setInfo: (state, newInfo) => {
+            let oldVersion = state.info.api_version;
             state.info = newInfo;
+            if (oldVersion && oldVersion !== newInfo.api_version) {
+                state.needReload = true;
+            }
         },
     },
 


### PR DESCRIPTION
Ask the user to reload the page when the api has been updated.

This should prevent errors in long running front-ends.

Also, when deploying the UI before the API, updating the API will automatically prompt the user to reload the web site.